### PR TITLE
fix: Senses are in attributes not traits

### DIFF
--- a/template/dndb-npc-sheet.html
+++ b/template/dndb-npc-sheet.html
@@ -103,7 +103,7 @@
                         <div class="property-line">
                             <div>
                                 <h4>{{localize "DND5E.Senses"}}</h4> 
-                                <p>{{data.traits.senses}}</p>
+                                <p>{{data.attributes.senses}}</p>
                             </div>
                         </div>
                         <div class="property-line">


### PR DESCRIPTION
I noticed that `senses` weren't showing up in the NPC sheets when I was using this sheet type. Looked at the object structure and `senses` is in attributes now